### PR TITLE
Tests and linting CI

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn' # installs dependencies
+    - run: yarn test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -47,4 +47,4 @@ jobs:
         run: yarn install
 
       - name: Run Tests
-        run: yarn test:ci
+        run: yarn test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -17,6 +17,7 @@ jobs:
         working-directory: server
 
     steps:
+      - uses: actions/checkout@v1
       - uses: actions/cache@v2
         with:
           path: server/node_modules
@@ -36,6 +37,7 @@ jobs:
         working-directory: server
 
     steps:
+      - uses: actions/checkout@v1
       - uses: actions/cache@v2
         with:
           path: server/node_modules

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - run: cd backend
+    - run: cd server
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -10,26 +10,6 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        with:
-          path: server/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install packages
-        run: yarn install
-
-      - name: Run Typescript Checks
-        run: yarn lint
-        
-
   test:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
+        working-directory: server
         node-version: ${{ matrix.node-version }}
         cache: 'yarn' # installs dependencies
     - run: yarn test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -30,4 +30,5 @@ jobs:
         cache-dependency-path: server/yarn.lock
         node-version: ${{ matrix.node-version }}
         cache: 'yarn' # installs dependencies
+    - run: yarn lint
     - run: yarn test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: CI (test)
 
 on:
   push:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-server:
 
     runs-on: ubuntu-latest
 
@@ -18,10 +18,12 @@ jobs:
       matrix:
         node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    defaults:
+      run:
+        working-directory: server
 
     steps:
     - uses: actions/checkout@v3
-    - run: cd server
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: CI (test)
+name: Automated Lint and Test
 
 on:
   push:
@@ -10,25 +10,39 @@ on:
     branches: [ master ]
 
 jobs:
-  build-server:
-
+  lint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     defaults:
       run:
         working-directory: server
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        cache-dependency-path: server/yarn.lock
-        node-version: ${{ matrix.node-version }}
-        cache: 'yarn' # installs dependencies
-    - run: yarn lint
-    - run: yarn test
+      - uses: actions/cache@v2
+        with:
+          path: server/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        run: yarn install
+
+      - name: Run Typescript Checks
+        run: yarn lint
+        
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: server/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        run: yarn install
+
+      - name: Run Tests
+        run: yarn test:ci

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        working-directory: server
+        cache-dependency-path: server/yarn.lock
         node-version: ${{ matrix.node-version }}
         cache: 'yarn' # installs dependencies
     - run: yarn test

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - run: cd backend
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-yarnPath: .yarn/releases/yarn-1.23.0-20220130.1630.cjs


### PR DESCRIPTION
Obviously depends on #27, tests action currently fail on my fork, but it is similar enough to the linting action to guarantee it will work, once testing is in place.

I did on a separate fork because it is a lot of actions CI trial-and-error, and did not want to commit-spam. It was the easiest proven working method to try stuff with GitHub CI. So, as to avoid commit-spam, we should squash this before merging.