### PR TITLE
New feature: Resend confirmation email

### DIFF
--- a/server/src/models/exceptions/UserAlreadyExistsError.ts
+++ b/server/src/models/exceptions/UserAlreadyExistsError.ts
@@ -1,0 +1,8 @@
+// Create Error UserAlreadyExistsError
+export default class UserAlreadyExistsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UserAlreadyExistsError';
+    Object.setPrototypeOf(this, UserAlreadyExistsError.prototype);
+  }
+}

--- a/server/src/routes/users.routes.ts
+++ b/server/src/routes/users.routes.ts
@@ -7,12 +7,13 @@ import ResetUserPasswordService from '../services/ResetUserPasswordService';
 import DeleteUserService from '../services/DeleteUserService';
 import ensureAuthenticated from '../middlewares/ensureAuthenticated';
 import Queue from '../services/Queue';
-import SendConfirmAccountMail from '../jobs/SendConfirmAccountMail';
 import SendResetPasswordMail from '../jobs/SendResetPasswordMail';
 import authConfig from '../config/auth';
-import User from '../models/User';
 import SendDataExportMail from '../jobs/SendDataExportMail';
 import Notification from '../models/Notification';
+import User from '../models/User';
+import UserAlreadyExistsError from '../models/exceptions/UserAlreadyExistsError';
+import sendConfirmationMail from '../utils/sendConfirmationEmail';
 
 const usersRouter = Router();
 
@@ -131,26 +132,31 @@ usersRouter.post('/', async (request, response, next) => {
     const createUser = new CreateUserService();
     const user = await createUser.execute({ email, password });
 
-    // Create confirmation token so that the user can confirm their account
-    const EMAIL_SECRET = authConfig.jwt.secret;
-    const emailToken = sign(
-      {
-        user,
-      },
-      EMAIL_SECRET as string,
-      {
-        expiresIn: authConfig.jwt.expiresIn,
-      },
-    );
-
-    // Add confirmation email task to the queue, so that it will be sent to the user
-    await Queue.add(SendConfirmAccountMail.key, {
-      token: emailToken,
-      user,
-    });
+    if (user) {
+      sendConfirmationMail(user);
+    }
 
     return response.json(user);
   } catch (err) {
+    if (err instanceof UserAlreadyExistsError) {
+      const { email } = request.body;
+      const user = await getRepository(User).findOne({
+        where: { email },
+      });
+
+      if (user && !user.confirmed) {
+        sendConfirmationMail(user);
+
+        return response
+          .status(400)
+          .json({ error: `${err.message} Confirmation email resent.` });
+      }
+
+      return response.status(400).json({
+        error: `${err.message} User is already confirmed, so confirmation email was not resent.`,
+      });
+    }
+
     if (err instanceof Error) {
       return response.status(400).json({ error: err.message });
     }

--- a/server/src/services/CreateUserService.ts
+++ b/server/src/services/CreateUserService.ts
@@ -2,6 +2,7 @@ import { getRepository } from 'typeorm';
 import { hash } from 'bcryptjs';
 import User from '../models/User';
 import { UserOptionalPassword } from '../@types/alertadotesouro';
+import UserAlreadyExistsError from '../models/exceptions/UserAlreadyExistsError';
 
 /**
  * Interface for the request object for creating a new User.
@@ -20,12 +21,12 @@ class CreateUserService {
   public async execute({ email, password }: Request): Promise<User> {
     const usersRepository = getRepository(User);
 
-    const findUser: User | undefined  = await usersRepository.findOne({
+    const findUser: User | undefined = await usersRepository.findOne({
       where: { email },
     });
 
     if (findUser) {
-      throw new Error('E-mail address is already being used.');
+      throw new UserAlreadyExistsError('E-mail address is already being used.');
     }
 
     const hashedPassword = await hash(password, 8);

--- a/server/src/utils/sendConfirmationEmail.ts
+++ b/server/src/utils/sendConfirmationEmail.ts
@@ -1,0 +1,24 @@
+import { sign } from 'jsonwebtoken';
+import SendConfirmAccountMail from '../jobs/SendConfirmAccountMail';
+import User from '../models/User';
+import Queue from '../services/Queue';
+import authConfig from '../config/auth';
+
+export default function sendConfirmationMail(user: User): void {
+  const EMAIL_SECRET = authConfig.jwt.secret;
+  const emailToken = sign(
+    {
+      user,
+    },
+    EMAIL_SECRET as string,
+    {
+      expiresIn: authConfig.jwt.expiresIn,
+    },
+  );
+
+  // Add confirmation email task to the queue, so that it will be sent to the user
+  Queue.add(SendConfirmAccountMail.key, {
+    token: emailToken,
+    user,
+  });
+}


### PR DESCRIPTION
Trying to create a new account with an existing email will resend a confirmation email if the account has not been confirmed yet.

Resolves #48.